### PR TITLE
Bridge docs review: Update relayer_service.mdx

### DIFF
--- a/docs/bridge/relayer_service.mdx
+++ b/docs/bridge/relayer_service.mdx
@@ -9,10 +9,10 @@ This enables seamless interoperability and data transfer between the two chains.
 <img src={require('@site/static/img/relayer_simple.jpg').default} />
 
 ## NEAR to Calimero Relayer
-The NEAR to Calimero relayer specifically focuses on relaying blocks from the NEAR blockchain to the designated light client contract on the Calimero shard. Information is relayed when needed (Calimero event occurred on the opposite side or one in the epoch). By actively monitoring the NEAR blockchain for the latest blocks, the relayer ensures that the most up-to-date information is relayed to the Calimero shard.
+The NEAR to Calimero relayer specifically focuses on relaying blocks from the NEAR blockchain to the designated light client contract on the Calimero shard. Information is relayed when needed (Calimero event occurred on the opposite side or once per the epoch). The relayer acts on the messages received from the events indexer.
 
 ## Calimero to NEAR Relayer
-Similarly, the Calimero to NEAR relayer performs the opposite function by relaying blocks from the Calimero shards to the light client contract on the NEAR blockchain. By reading the latest blocks on the Calimero shards, the relayer facilitates the transfer of relevant information to the NEAR blockchain, ensuring consistency and interoperability between the two chains.
+Similarly, the Calimero to NEAR relayer performs the opposite function by relaying blocks from the Calimero shards to individual light client contracts on the NEAR blockchain. Each Calimero shard has its own dedicated light client contract on the NEAR side (one per shard with a bridge installed). The relayer operates based on the messages received from the events indexer.
 
 ## Light Client Block Structure
 The light client block structure represents the data that is relayed by the relayer. It consists of several substructures that provide essential details about the block being relayed. 


### PR DESCRIPTION
https://docs.calimero.network/bridge/relayer_service#near-to-calimero-relayer
> (Calimero event occurred on the opposite side or one in the epoch)

I think that we should change “one in” to “once per”


> By actively monitoring the NEAR blockchain for the latest blocks, the relayer ensures that the most up-to-date information is relayed to the Calimero shard.

I think this is a bit confusing since the relayer does not monitor the blockchain, that is the task of the events indexer and the relayer acts on the messages received from the events indexer (edited) 
—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-
https://docs.calimero.network/bridge/relayer_service#calimero-to-near-relayer
> Similarly, the Calimero to NEAR relayer performs the opposite function by relaying blocks from the Calimero shards to the light client contract on the NEAR blockchain. 

Is it possible to specify here that the light client contract on the NEAR side is not shared between Calimero shards? We deploy one light client contract on the NEAR side per shard (that has a bridge installed).

> By reading the latest blocks on the Calimero shards,

Also, like before I would specify that the relayer is not reading the blockchain.
