### PR TITLE
Bridge docs review: Update light_client_contract.mdx

### DIFF
--- a/docs/bridge/light_client_contract.mdx
+++ b/docs/bridge/light_client_contract.mdx
@@ -3,7 +3,7 @@ title: Light Client Contract
 sidebar_position: 3
 ---
 
-The Light Client Contract plays a crucial role in enabling interoperability between the NEAR (mainnet or testnet) and Calimero shard. It provides implementations of the NEAR light client as a contract, allowing for the relay of block headers and validation of their authenticity. There are two possible scenarios where the Light Client Contract is utilized: bridging from the NEAR to the Calimero shard or bridging between Calimero shards for various use cases.
+The Light Client Contract plays a crucial role in enabling interoperability between the NEAR Mainnet or Testnet and Calimero shard. It provides implementations of the NEAR light client as a contract, allowing for the relay of block headers and validation of their authenticity. There are two possible scenarios where the Light Client Contract is utilized: bridging from the NEAR to the Calimero shard or bridging between Calimero shards for various use cases.
 
 ## Validation Criteria for Block Headers
 

--- a/docs/bridge/light_client_contract.mdx
+++ b/docs/bridge/light_client_contract.mdx
@@ -3,7 +3,7 @@ title: Light Client Contract
 sidebar_position: 3
 ---
 
-The Light Client Contract plays a crucial role in enabling interoperability between the NEAR Mainnet or Testnet and Calimero shard. It provides implementations of the NEAR light client as a contract, allowing for the relay of block headers and validation of their authenticity. There are two possible scenarios where the Light Client Contract is utilized: bridging from the NEAR to the Calimero shard or bridging between Calimero shards for various use cases.
+The Light Client Contract is a key component that makes it easy for the NEAR blockchain Mainnet or Testnet to communicate with the Calimero shard. It acts as a bridge, allowing block headers to be relayed and verified seamlessly. Its primary role is to facilitate smooth communication between NEAR and Calimero, making interoperability simple and efficient.
 
 ## Validation Criteria for Block Headers
 

--- a/docs/bridge/light_client_contract.mdx
+++ b/docs/bridge/light_client_contract.mdx
@@ -18,18 +18,27 @@ A notable advantage of the Light Client Contract is its ability to efficiently v
 
 ## Head Update Conditions
 
-The Light Client Contract updates its head based on the information from the `LightClientBlockView` if the following conditions are met:
+The Light Client Contract updates its head based on information from the `LightClientBlockView` when the following conditions are met:
 
-- The height of the block is higher than the height of the current head.
-- The epoch of the block is equal to the `epoch_id` or `next_epoch_id` known for the current head.
-- If the epoch of the block is equal to the `next_epoch_id` of the head, then `next_bps` (next block producers) is not None. Additionally, `approvals_after_next` must contain valid signatures on the `approval_message` from the block producers of the corresponding epoch.
-- The signatures present in `approvals_after_next` correspond to more than two-thirds of the total stake.
-- If `next_bps` is not None, `sha256(borsh(next_bps))` corresponds to the `next_bp_hash` in `inner_lite`.
+1. The block's height is higher than the current head's height.
+2. The epoch of the block matches either the `epoch_id` or `next_epoch_id` known for the current head.
 
-## Considerations for Calimero on NEAR Light Client
+This requirement to relay at least one block per epoch is essential because the `Epoch Id` for epoch number X is derived from the hash of the last block of epoch X-2. Additionally, in the current epoch, there is crucial information about the validators for the next epoch.
 
-For the Calimero on the NEAR light client, there is a limitation due to NEAR's transaction gas limit of 300 Tgas per transaction. Since signature verifications are computationally expensive, performing a large number of signature checks (approximately 50) can exceed this limit and cause transaction failures. However, there is good news on the horizon. [NEP364](https://github.com/near/nearcore/issues/7567) is currently in progress, which aims to add `ed25519_verify` as a precompiled function in the NEAR runtime. Once implemented, this precompiled function will allow the efficient verification of up to 100 validator signatures on every relayed block.
+Furthermore, if the epoch of the block is the same as the `next_epoch_id` of the current head, the following additional checks are performed:
+
+1. Ensure that `next_bps` (next block producers) is not None.
+2. Validate that `approvals_after_next` contains valid signatures on the `approval_message` from the block producers of the corresponding epoch.
+3. Confirm that the signatures in `approvals_after_next` represent more than two-thirds of the total stake.
+
+Finally, if `next_bps` is not None, the contract verifies that `sha256(borsh(next_bps))` corresponds to the `next_bp_hash` in `inner_lite`.
+
+## Considerations for Calimero with NEAR Light Client
+
+When using Calimero with the NEAR light client, one limitation arises due to NEAR's transaction gas limit, set at 300 Tgas per transaction. As signature verifications are computationally intensive, conducting a significant number of such checks (approximately 50) may surpass this limit, resulting in transaction failures.
+
+However, there's promising news on the horizon. Work is underway on [NEP364](https://github.com/near/nearcore/issues/7567), aiming to introduce `ed25519_verify` as a precompiled function in the NEAR runtime. Once implemented, this precompiled function will efficiently verify up to 100 validator signatures on each relayed block.
 
 ## Gas Cost Considerations for NEAR on Calimero Light Client
 
-In contrast, the signature verification cost is not a significant concern for the NEAR on the Calimero light client contract. Native Calimero tokens do not have any monetary value, they are just used as a consensus mechanism. The shard creator has the ability to set up the genesis block in such a way that the gas costs are cheaper, ensuring that the signature verification process remains within acceptable limits. This provides flexibility in managing gas costs for signature verification in the context of NEAR on Calimero.
+In contrast, the signature verification cost is not a significant concern for the NEAR on the Calimero light client contract. Native Calimero tokens do not have any monetary value, they are just used as a consensus mechanism. The shard creator enjoys the freedom to configure the genesis block in a manner that optimizes gas costs, potentially making signature verification more affordable. Additionally, as an advantage, gas can even become free, and the default gas limit of 300 Tgas can be increased if needed. This provides flexibility in managing gas costs for signature verification in the context of NEAR on Calimero.


### PR DESCRIPTION
https://docs.calimero.network/bridge/light_client_contract
> The Light Client Contract plays a crucial role in enabling interoperability between the NEAR (mainnet or testnet)


Not very important but I would use “Mainnet or Testnet” and not “mainnet or testnet” 
—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-
https://docs.calimero.network/bridge/light_client_contract
> There are two possible scenarios where the Light Client Contract is utilized: bridging from the NEAR to the Calimero shard or bridging between Calimero shards for various use cases.

Here we just drop that we offer Calimero <-> Calimero bridge. This is not implemented at the moment so I am not sure we should write about this. And if we want to keep this here I think we would mention that in the Architecture part too. Text from Architecture part:

> The Calimero Bridge handles the transfer of various assets, including fungible and non-fungible tokens, between the NEAR public network (Testnet or Mainnet) and the Calimero private shard.

I think that Sandi or Gleb should decide if we want to keep this Calimero <-> Calimero part in the documentation.
—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-
https://docs.calimero.network/bridge/light_client_contract#head-update-conditions

> The epoch of the block is equal to the epoch_id or next_epoch_id known for the current head.

Maybe explain here (under all those rules) that this is the reason we need to relay at least 1 block per epoch. The concrete reason for this is that Epoch Id for epoch number X is the hash of the last block of the epoch X-2 and that in the current epoch, there is information about the validators for the next epoch.
—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-
https://docs.calimero.network/bridge/light_client_contract#considerations-for-calimero-on-near-light-client

> Considerations for Calimero on NEAR Light Client


Is there some better way to say this “Calimero on NEAR Light Client”, this was not clear to me prior to reading the text under the title. Same for the title below. Maybe just change “on” to “to”.

—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-—-
https://docs.calimero.network/bridge/light_client_contract#gas-cost-considerations-for-near-on-calimero-light-client

> The shard creator has the ability to set up the genesis block in such a way that the gas costs are cheaper, ensuring that the signature verification process remains within acceptable limits. 

I would add here that gas can become free, and that limit can be increased from the default value of 300 Tgas to a bigger value if needed.
