### PR TITLE
Bridge docs review: Update light_client_prover.mdx

### DIFF
--- a/docs/bridge/light_client_prover.mdx
+++ b/docs/bridge/light_client_prover.mdx
@@ -3,7 +3,7 @@ title: Prover Contract
 sidebar_position: 4
 ---
 
-The Prover contract plays a crucial role in verifying transactions that occur on the opposite chain (e.g., the Calimero side if the Prover contract is on the Near side). To verify a transaction, the Prover contract requires the Merkle tree root for a specific block height. It obtains this information by making an RPC call (EXPERIMENTAL_light_client_proof) to the Archival node and retrieving the proof for a particular receipt.
+The Prover contract is essential for verifying transactions that occur on the opposite chain (for example, on the Calimero side, if the Prover contract is on the NEAR side). To validate a transaction, the Prover contract needs the Merkle tree root for a specific block height. The Bridge Service handles this process by making an RPC call (EXPERIMENTAL_light_client_proof) to the Archival node. This call retrieves the proof for a particular receipt, which is then passed as an argument to the Prover contract.
 
 ## Proof Data Structure
 
@@ -92,9 +92,7 @@ pub struct ExecutionOutcome {
     pub receipt_ids: Vec<Hash>,
     /// The amount of gas burnt by the given transaction or receipt. 
     pub gas_burnt: u64,     
-    /// The total number of tokens burnt
-
- by the given transaction or receipt.
+    /// The total number of tokens burnt by the given transaction or receipt.
     pub tokens_burnt: u128, 
     /// The transaction or receipt ID that produced this outcome.
     pub executor_id: String, 


### PR DESCRIPTION
Changes made:

> It obtains this information by making an RPC call (EXPERIMENTAL_light_client_proof) to the Archival node and retrieving the proof for a particular receipt.

I would explain here that the RPC call is done by the bridge service and the result is passed as an argument to the prover smart contract call. From the current phrasing, I understand that this RPC call is done by the prover contract.

> pub tokens_burnt: u128,

The comment above this line is not formatted correctly.
